### PR TITLE
Use /bin/bash enviroment var to configure the ShellPath

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -45,6 +45,7 @@ var initCmd = &cobra.Command{
 
 		config := ssh.NewConfig(apiKey)
 		config.Save()
+		fmt.Println("* You can edit your config at anytime in " + ssh.DataPath + "/config.yml")
 	},
 }
 

--- a/ssh/config.go
+++ b/ssh/config.go
@@ -1,6 +1,7 @@
 package ssh
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 
@@ -26,9 +27,15 @@ func NewConfig(apiKey string) *Config {
 		APIKey: apiKey,
 	}
 
-	// Find some other safe default?
-	config.ShellPath = "/bin/sh"
+	shell := os.Getenv("SHELL")
+	if len(shell) == 0 {
+		shell = "/bin/sh"
+	}
+
+	config.ShellPath = shell
 	config.ShellArgs = make([]string, 0)
+
+	fmt.Println("Your users will be logged in a '" + shell + "' shell")
 
 	return config
 }


### PR DESCRIPTION
- Inform users about which shell has configured and how to change the configuration